### PR TITLE
add -doxygen to swig

### DIFF
--- a/swig/build.sh
+++ b/swig/build.sh
@@ -4,4 +4,4 @@ rm -rf $javaOutputDir
 mkdir $javaOutputDir
 rm ${cppOutputDir}/jctp.cpp
 rm ${cppOutputDir}/jctp.h
-swig -c++ -java -package org.rationalityfrontline.jctp -outdir $javaOutputDir -o $cppOutputDir/jctp.cpp jctp.i
+swig -c++ -java -doxygen -package org.rationalityfrontline.jctp -outdir $javaOutputDir -o $cppOutputDir/jctp.cpp jctp.i


### PR DESCRIPTION
to keep the comments in Java source, in GB2312 charset
todo: use iconv or enca command to convert Java source file comment to UTF8